### PR TITLE
fix: encode NULL params as None instead of empty bytes (#20)

### DIFF
--- a/crates/sentinel-driver/src/connection/client.rs
+++ b/crates/sentinel-driver/src/connection/client.rs
@@ -111,9 +111,13 @@ impl Connection {
         let mut encoded_params: Vec<Option<Vec<u8>>> = Vec::with_capacity(params.len());
 
         for param in params {
-            let mut buf = BytesMut::new();
-            param.to_sql(&mut buf)?;
-            encoded_params.push(Some(buf.to_vec()));
+            if param.is_null() {
+                encoded_params.push(None);
+            } else {
+                let mut buf = BytesMut::new();
+                param.to_sql(&mut buf)?;
+                encoded_params.push(Some(buf.to_vec()));
+            }
         }
 
         // Use pipeline for single query (same protocol, consistent code path)

--- a/crates/sentinel-driver/src/types/traits.rs
+++ b/crates/sentinel-driver/src/types/traits.rs
@@ -19,6 +19,15 @@ pub trait ToSql {
         self.to_sql(&mut buf)?;
         Ok(buf.to_vec())
     }
+
+    /// Returns `true` if this value represents SQL NULL.
+    ///
+    /// Used by the parameter encoding layer to send the correct wire
+    /// protocol NULL marker (length = -1) instead of an empty byte array.
+    /// Default: `false`. Overridden by `Option<T>` to return `true` for `None`.
+    fn is_null(&self) -> bool {
+        false
+    }
 }
 
 /// Decode a Rust value from PostgreSQL binary format.
@@ -75,6 +84,10 @@ impl<T: ToSql> ToSql for Option<T> {
             Some(v) => v.to_sql(buf),
             None => Ok(()), // caller handles NULL encoding (-1 length)
         }
+    }
+
+    fn is_null(&self) -> bool {
+        self.is_none()
     }
 }
 

--- a/tests/core/types/encode.rs
+++ b/tests/core/types/encode.rs
@@ -317,3 +317,64 @@ fn test_option_from_sql_oid() {
     assert_eq!(<Option<i32> as FromSql>::oid(), Oid::INT4);
     assert_eq!(<Option<String> as FromSql>::oid(), Oid::TEXT);
 }
+
+#[test]
+fn test_is_null_default_false() {
+    let val = 42i32;
+    assert!(!val.is_null());
+}
+
+#[test]
+fn test_is_null_option_none() {
+    let val: Option<i32> = None;
+    assert!(val.is_null());
+}
+
+#[test]
+fn test_is_null_option_some() {
+    let val: Option<i32> = Some(42);
+    assert!(!val.is_null());
+}
+
+#[test]
+fn test_null_param_encodes_as_none() {
+    // Simulate the fixed query_internal encoding logic
+    let params: Vec<&(dyn sentinel_driver::ToSql + Sync)> = vec![&None::<i32>];
+    let mut encoded: Vec<Option<Vec<u8>>> = Vec::new();
+
+    for param in &params {
+        if param.is_null() {
+            encoded.push(None);
+        } else {
+            let mut buf = BytesMut::new();
+            param.to_sql(&mut buf).unwrap();
+            encoded.push(Some(buf.to_vec()));
+        }
+    }
+
+    assert_eq!(encoded.len(), 1);
+    assert!(
+        encoded[0].is_none(),
+        "NULL param must encode as None, not Some(empty)"
+    );
+}
+
+#[test]
+fn test_non_null_param_encodes_as_some() {
+    let params: Vec<&(dyn sentinel_driver::ToSql + Sync)> = vec![&42i32];
+    let mut encoded: Vec<Option<Vec<u8>>> = Vec::new();
+
+    for param in &params {
+        if param.is_null() {
+            encoded.push(None);
+        } else {
+            let mut buf = BytesMut::new();
+            param.to_sql(&mut buf).unwrap();
+            encoded.push(Some(buf.to_vec()));
+        }
+    }
+
+    assert_eq!(encoded.len(), 1);
+    assert!(encoded[0].is_some());
+    assert_eq!(encoded[0].as_ref().unwrap(), &42i32.to_be_bytes());
+}


### PR DESCRIPTION
## Summary
- Add `is_null()` method to `ToSql` trait (default `false`), overridden by `Option<T>` to return `true` for `None`
- Fix `query_internal()` param encoding loop to check `is_null()` and push `None` for NULL params — wire protocol now sends length=-1 (SQL NULL) instead of length=0 (empty string)
- 5 new tests covering `is_null()` behavior and NULL/non-NULL encoding

## Root Cause
`connection/client.rs` always pushed `Some(buf.to_vec())` for every param, even when `Option<T>::None` produced an empty buffer. The `&dyn ToSql` erased type info, making it impossible to distinguish None from a genuinely empty value without a trait method.

## Test Plan
- [x] 338 tests pass (333 existing + 5 new)
- [x] 17 postgres integration tests pass
- [x] Clippy zero warnings
- [x] `cargo fmt` clean

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)