### PR TITLE
feat: add ecosystem types — Phase 4D

### DIFF
--- a/crates/sentinel-driver/Cargo.toml
+++ b/crates/sentinel-driver/Cargo.toml
@@ -55,12 +55,14 @@ sentinel-derive = { version = "0.1.0", path = "../sentinel-derive", optional = t
 rust_decimal = { version = "1", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
+time = { version = "0.3", optional = true, features = ["std"] }
 
 [features]
 default = ["derive"]
 derive = ["dep:sentinel-derive"]
 with-rust-decimal = ["dep:rust_decimal"]
 with-serde-json = ["dep:serde", "dep:serde_json"]
+with-time = ["dep:time"]
 
 [lints]
 workspace = true
@@ -68,6 +70,7 @@ workspace = true
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 criterion = { version = "0.5", features = ["html_reports"] }
+time = { version = "0.3", features = ["std", "macros"] }
 
 [[test]]
 name = "core_tests"

--- a/crates/sentinel-driver/src/types/cube.rs
+++ b/crates/sentinel-driver/src/types/cube.rs
@@ -1,0 +1,169 @@
+use bytes::{BufMut, BytesMut};
+
+use crate::error::{Error, Result};
+use crate::types::{FromSql, Oid, ToSql};
+
+/// PostgreSQL CUBE type -- an n-dimensional point or box.
+///
+/// CUBE is a PostgreSQL extension type for multi-dimensional geometric data.
+/// It represents either a point (all dimensions equal) or a box (two corners).
+///
+/// Binary wire format:
+/// - `ndim` (u32): number of dimensions
+/// - `flags` (u32): bit 0 = is_point
+/// - coordinates: `ndim` f64 values for points, `ndim * 2` for boxes
+///
+/// Uses TEXT OID as carrier since CUBE is an extension type.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PgCube {
+    /// For a point: `[x, y, z, ...]` (ndim values).
+    /// For a box: `[x1, y1, z1, ..., x2, y2, z2, ...]` (ndim * 2 values).
+    pub coordinates: Vec<f64>,
+    /// True if this represents a point, false if a box.
+    pub is_point: bool,
+}
+
+const CUBE_IS_POINT: u32 = 1;
+
+impl PgCube {
+    /// Create a point with the given coordinates.
+    pub fn point(coordinates: Vec<f64>) -> Self {
+        PgCube {
+            coordinates,
+            is_point: true,
+        }
+    }
+
+    /// Create a box with the given coordinates and number of dimensions.
+    ///
+    /// `coordinates` must have exactly `ndim * 2` values:
+    /// the first `ndim` are the lower-left corner, the last `ndim` are the upper-right.
+    pub fn cube(coordinates: Vec<f64>, ndim: usize) -> Self {
+        debug_assert_eq!(
+            coordinates.len(),
+            ndim * 2,
+            "box coordinates must be ndim * 2"
+        );
+        PgCube {
+            coordinates,
+            is_point: false,
+        }
+    }
+
+    /// Number of dimensions.
+    pub fn ndim(&self) -> usize {
+        if self.is_point {
+            self.coordinates.len()
+        } else if self.coordinates.is_empty() {
+            0
+        } else {
+            self.coordinates.len() / 2
+        }
+    }
+}
+
+impl ToSql for PgCube {
+    fn oid(&self) -> Oid {
+        Oid::TEXT
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        let ndim = self.ndim() as u32;
+        let flags = if self.is_point { CUBE_IS_POINT } else { 0 };
+
+        buf.put_u32(ndim);
+        buf.put_u32(flags);
+
+        for &coord in &self.coordinates {
+            buf.put_f64(coord);
+        }
+
+        Ok(())
+    }
+}
+
+impl FromSql for PgCube {
+    fn oid() -> Oid {
+        Oid::TEXT
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        if buf.len() < 8 {
+            return Err(Error::Decode(format!(
+                "cube: expected at least 8 bytes, got {}",
+                buf.len()
+            )));
+        }
+
+        let ndim = u32::from_be_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        let flags = u32::from_be_bytes([buf[4], buf[5], buf[6], buf[7]]);
+        let is_point = (flags & CUBE_IS_POINT) != 0;
+
+        let num_coords = if is_point { ndim } else { ndim * 2 };
+        let expected_len = 8 + num_coords * 8;
+
+        if buf.len() < expected_len {
+            return Err(Error::Decode(format!(
+                "cube: expected {} bytes for {ndim}D {}, got {}",
+                expected_len,
+                if is_point { "point" } else { "box" },
+                buf.len()
+            )));
+        }
+
+        let mut coordinates = Vec::with_capacity(num_coords);
+        let mut offset = 8;
+        for _ in 0..num_coords {
+            let val = f64::from_be_bytes([
+                buf[offset],
+                buf[offset + 1],
+                buf[offset + 2],
+                buf[offset + 3],
+                buf[offset + 4],
+                buf[offset + 5],
+                buf[offset + 6],
+                buf[offset + 7],
+            ]);
+            coordinates.push(val);
+            offset += 8;
+        }
+
+        Ok(PgCube {
+            coordinates,
+            is_point,
+        })
+    }
+}
+
+impl std::fmt::Display for PgCube {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_point {
+            write!(f, "(")?;
+            for (i, coord) in self.coordinates.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{coord}")?;
+            }
+            write!(f, ")")
+        } else {
+            let ndim = self.ndim();
+            let (lower, upper) = self.coordinates.split_at(ndim);
+            write!(f, "(")?;
+            for (i, coord) in lower.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{coord}")?;
+            }
+            write!(f, "),(")?;
+            for (i, coord) in upper.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{coord}")?;
+            }
+            write!(f, ")")
+        }
+    }
+}

--- a/crates/sentinel-driver/src/types/ltree.rs
+++ b/crates/sentinel-driver/src/types/ltree.rs
@@ -1,0 +1,98 @@
+use bytes::{BufMut, BytesMut};
+
+use crate::error::{Error, Result};
+use crate::types::{FromSql, Oid, ToSql};
+
+/// PostgreSQL LTREE type -- a dot-separated label path for hierarchical data.
+///
+/// LTREE is a PostgreSQL extension type used for representing labels of data
+/// stored in a hierarchical tree-like structure. Example: `"top.science.astronomy"`.
+///
+/// Wire format: UTF-8 text bytes (same as TEXT). Uses TEXT OID as carrier
+/// since LTREE is an extension type without a stable OID.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PgLTree(pub String);
+
+impl ToSql for PgLTree {
+    fn oid(&self) -> Oid {
+        Oid::TEXT
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        buf.put_slice(self.0.as_bytes());
+        Ok(())
+    }
+}
+
+impl FromSql for PgLTree {
+    fn oid() -> Oid {
+        Oid::TEXT
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        let s = String::from_utf8(buf.to_vec())
+            .map_err(|e| Error::Decode(format!("ltree: invalid UTF-8: {e}")))?;
+        Ok(PgLTree(s))
+    }
+}
+
+impl std::fmt::Display for PgLTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for PgLTree {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(PgLTree(s.to_owned()))
+    }
+}
+
+/// PostgreSQL LQUERY type -- a pattern for matching LTREE paths.
+///
+/// LQUERY extends LTREE with pattern-matching syntax including `*` (any label),
+/// `*{n}` (exactly n labels), and `*{n,m}` (between n and m labels).
+/// Example: `"*.science.*"` matches any path containing "science".
+///
+/// Wire format: UTF-8 text bytes (same as TEXT). Uses TEXT OID as carrier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PgLQuery(pub String);
+
+impl ToSql for PgLQuery {
+    fn oid(&self) -> Oid {
+        Oid::TEXT
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        buf.put_slice(self.0.as_bytes());
+        Ok(())
+    }
+}
+
+impl FromSql for PgLQuery {
+    fn oid() -> Oid {
+        Oid::TEXT
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        let s = String::from_utf8(buf.to_vec())
+            .map_err(|e| Error::Decode(format!("lquery: invalid UTF-8: {e}")))?;
+        Ok(PgLQuery(s))
+    }
+}
+
+impl std::fmt::Display for PgLQuery {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::str::FromStr for PgLQuery {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(PgLQuery(s.to_owned()))
+    }
+}

--- a/crates/sentinel-driver/src/types/mod.rs
+++ b/crates/sentinel-driver/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod bit;
 pub mod builtin;
+pub mod cube;
 pub mod decode;
 pub mod encode;
 pub mod geometric;
@@ -8,6 +9,7 @@ pub mod interval;
 #[cfg(feature = "with-serde-json")]
 pub mod json;
 pub mod lsn;
+pub mod ltree;
 pub mod money;
 pub mod multirange;
 pub mod network;
@@ -15,6 +17,8 @@ pub mod network;
 pub mod numeric;
 pub mod oid;
 pub mod range;
+#[cfg(feature = "with-time")]
+pub mod time_support;
 pub mod timetz;
 pub mod traits;
 pub mod xml;

--- a/crates/sentinel-driver/src/types/time_support.rs
+++ b/crates/sentinel-driver/src/types/time_support.rs
@@ -1,0 +1,144 @@
+//! Feature-gated `time` crate support for PostgreSQL date/time types.
+//!
+//! Enabled with the `with-time` feature. Provides an alternative to chrono
+//! for date/time encoding and decoding.
+//!
+//! | Rust type                  | PG type      | OID  |
+//! |----------------------------|-------------|------|
+//! | `time::OffsetDateTime`     | TIMESTAMPTZ | 1184 |
+//! | `time::PrimitiveDateTime`  | TIMESTAMP   | 1114 |
+//! | `time::Date`               | DATE        | 1082 |
+//! | `time::Time`               | TIME        | 1083 |
+
+use bytes::{BufMut, BytesMut};
+
+use crate::error::{Error, Result};
+use crate::types::{FromSql, Oid, ToSql};
+
+/// PG epoch offset in microseconds from Unix epoch.
+/// Unix epoch: 1970-01-01, PG epoch: 2000-01-01.
+/// Difference: 10957 days * 86400 s/day * 1_000_000 us/s = 946_684_800_000_000 us.
+const PG_EPOCH_OFFSET_US: i64 = 946_684_800_000_000;
+
+/// PG epoch as Julian day number (2000-01-01).
+const PG_EPOCH_JULIAN_DAY: i32 = 2_451_545;
+
+// ── OffsetDateTime → TIMESTAMPTZ ────────────────────
+
+impl ToSql for time::OffsetDateTime {
+    fn oid(&self) -> Oid {
+        Oid::TIMESTAMPTZ
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        let unix_us = self.unix_timestamp() * 1_000_000 + i64::from(self.microsecond());
+        let pg_us = unix_us - PG_EPOCH_OFFSET_US;
+        buf.put_i64(pg_us);
+        Ok(())
+    }
+}
+
+impl FromSql for time::OffsetDateTime {
+    fn oid() -> Oid {
+        Oid::TIMESTAMPTZ
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        let pg_us = i64::from_sql(buf)?;
+        let unix_us = pg_us + PG_EPOCH_OFFSET_US;
+        let secs = unix_us.div_euclid(1_000_000);
+        let nanos = (unix_us.rem_euclid(1_000_000) * 1000) as i128;
+        let total_nanos = i128::from(secs) * 1_000_000_000 + nanos;
+        time::OffsetDateTime::from_unix_timestamp_nanos(total_nanos)
+            .map_err(|e| Error::Decode(format!("timestamptz (time): {e}")))
+    }
+}
+
+// ── PrimitiveDateTime → TIMESTAMP ───────────────────
+
+impl ToSql for time::PrimitiveDateTime {
+    fn oid(&self) -> Oid {
+        Oid::TIMESTAMP
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        // Treat PrimitiveDateTime as UTC for wire encoding (same as chrono::NaiveDateTime)
+        let as_utc = self.assume_utc();
+        let unix_us = as_utc.unix_timestamp() * 1_000_000 + i64::from(as_utc.microsecond());
+        let pg_us = unix_us - PG_EPOCH_OFFSET_US;
+        buf.put_i64(pg_us);
+        Ok(())
+    }
+}
+
+impl FromSql for time::PrimitiveDateTime {
+    fn oid() -> Oid {
+        Oid::TIMESTAMP
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        let odt = time::OffsetDateTime::from_sql(buf)?;
+        Ok(time::PrimitiveDateTime::new(odt.date(), odt.time()))
+    }
+}
+
+// ── Date → DATE ─────────────────────────────────────
+
+impl ToSql for time::Date {
+    fn oid(&self) -> Oid {
+        Oid::DATE
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        let days = self.to_julian_day() - PG_EPOCH_JULIAN_DAY;
+        buf.put_i32(days);
+        Ok(())
+    }
+}
+
+impl FromSql for time::Date {
+    fn oid() -> Oid {
+        Oid::DATE
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        let days = i32::from_sql(buf)?;
+        let julian = PG_EPOCH_JULIAN_DAY + days;
+        time::Date::from_julian_day(julian).map_err(|e| Error::Decode(format!("date (time): {e}")))
+    }
+}
+
+// ── Time → TIME ─────────────────────────────────────
+
+impl ToSql for time::Time {
+    fn oid(&self) -> Oid {
+        Oid::TIME
+    }
+
+    fn to_sql(&self, buf: &mut BytesMut) -> Result<()> {
+        let (h, m, s, us) = self.as_hms_micro();
+        let total_us = i64::from(h) * 3_600_000_000
+            + i64::from(m) * 60_000_000
+            + i64::from(s) * 1_000_000
+            + i64::from(us);
+        buf.put_i64(total_us);
+        Ok(())
+    }
+}
+
+impl FromSql for time::Time {
+    fn oid() -> Oid {
+        Oid::TIME
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        let us = i64::from_sql(buf)?;
+        let total_secs = (us / 1_000_000) as u32;
+        let micro = (us % 1_000_000) as u32;
+        let h = (total_secs / 3600) as u8;
+        let m = ((total_secs % 3600) / 60) as u8;
+        let s = (total_secs % 60) as u8;
+        time::Time::from_hms_micro(h, m, s, micro)
+            .map_err(|e| Error::Decode(format!("time (time): {e}")))
+    }
+}

--- a/tests/core/derive/domain.rs
+++ b/tests/core/derive/domain.rs
@@ -1,0 +1,127 @@
+use bytes::BytesMut;
+use sentinel_driver::types::{FromSql, Oid, ToSql};
+
+/// Domain type wrapping String — models `CREATE DOMAIN email AS text`.
+#[derive(Debug, PartialEq, sentinel_driver::ToSql, sentinel_driver::FromSql)]
+struct Email(String);
+
+/// Domain type wrapping i32 — models `CREATE DOMAIN user_id AS integer`.
+#[derive(Debug, PartialEq, sentinel_driver::ToSql, sentinel_driver::FromSql)]
+struct UserId(i32);
+
+/// Domain type wrapping f64 — models `CREATE DOMAIN temperature AS float8`.
+#[derive(Debug, PartialEq, sentinel_driver::ToSql, sentinel_driver::FromSql)]
+struct Temperature(f64);
+
+/// Domain type wrapping bool.
+#[derive(Debug, PartialEq, sentinel_driver::ToSql, sentinel_driver::FromSql)]
+struct IsActive(bool);
+
+// ── Roundtrip tests ─────────────────────────────────
+
+#[test]
+fn test_domain_email_roundtrip() {
+    let val = Email("user@example.com".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = Email::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_domain_user_id_roundtrip() {
+    let val = UserId(42);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = UserId::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_domain_temperature_roundtrip() {
+    let val = Temperature(36.6);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = Temperature::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_domain_bool_roundtrip() {
+    let val = IsActive(true);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = IsActive::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+// ── OID delegation tests ────────────────────────────
+
+#[test]
+fn test_domain_email_oid() {
+    let val = Email("test@test.com".into());
+    assert_eq!(val.oid(), Oid::TEXT);
+    assert_eq!(<Email as FromSql>::oid(), Oid::TEXT);
+}
+
+#[test]
+fn test_domain_user_id_oid() {
+    let val = UserId(1);
+    assert_eq!(val.oid(), Oid::INT4);
+    assert_eq!(<UserId as FromSql>::oid(), Oid::INT4);
+}
+
+#[test]
+fn test_domain_temperature_oid() {
+    let val = Temperature(0.0);
+    assert_eq!(val.oid(), Oid::FLOAT8);
+    assert_eq!(<Temperature as FromSql>::oid(), Oid::FLOAT8);
+}
+
+// ── Wire format tests ───────────────────────────────
+
+#[test]
+fn test_domain_email_wire_format() {
+    let val = Email("hi".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    // Should encode same as raw String
+    assert_eq!(&buf[..], b"hi");
+}
+
+#[test]
+fn test_domain_user_id_wire_format() {
+    let val = UserId(7);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &7i32.to_be_bytes());
+}
+
+// ── Edge cases ──────────────────────────────────────
+
+#[test]
+fn test_domain_email_empty_string() {
+    let val = Email(String::new());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = Email::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_domain_user_id_negative() {
+    let val = UserId(-1);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = UserId::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_domain_user_id_zero() {
+    let val = UserId(0);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = UserId::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}

--- a/tests/core/derive/mod.rs
+++ b/tests/core/derive/mod.rs
@@ -1,3 +1,4 @@
 mod composite;
+mod domain;
 mod enum_;
 mod from_row;

--- a/tests/core/types/cube.rs
+++ b/tests/core/types/cube.rs
@@ -1,0 +1,153 @@
+use bytes::BytesMut;
+use sentinel_driver::types::cube::PgCube;
+use sentinel_driver::types::{FromSql, Oid, ToSql};
+
+// ── Point roundtrips ────────────────────────────────
+
+#[test]
+fn test_cube_point_1d_roundtrip() {
+    let val = PgCube::point(vec![1.0]);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_cube_point_2d_roundtrip() {
+    let val = PgCube::point(vec![1.0, 2.0]);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_cube_point_3d_roundtrip() {
+    let val = PgCube::point(vec![1.0, 2.0, 3.0]);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+// ── Box roundtrips ──────────────────────────────────
+
+#[test]
+fn test_cube_box_2d_roundtrip() {
+    let val = PgCube::cube(vec![0.0, 0.0, 1.0, 1.0], 2);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_cube_box_3d_roundtrip() {
+    let val = PgCube::cube(vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0], 3);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+// ── OID ─────────────────────────────────────────────
+
+#[test]
+fn test_cube_oid() {
+    let val = PgCube::point(vec![1.0]);
+    assert_eq!(val.oid(), Oid::TEXT);
+    assert_eq!(<PgCube as FromSql>::oid(), Oid::TEXT);
+}
+
+// ── Wire format ─────────────────────────────────────
+
+#[test]
+fn test_cube_point_wire_format() {
+    let val = PgCube::point(vec![1.0, 2.0]);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+
+    // ndim(4) + flags(4) + 2 * f64(8) = 24 bytes
+    assert_eq!(buf.len(), 24);
+
+    // ndim = 2
+    assert_eq!(&buf[0..4], &2u32.to_be_bytes());
+    // flags = 1 (is_point)
+    assert_eq!(&buf[4..8], &1u32.to_be_bytes());
+    // x = 1.0
+    assert_eq!(&buf[8..16], &1.0f64.to_be_bytes());
+    // y = 2.0
+    assert_eq!(&buf[16..24], &2.0f64.to_be_bytes());
+}
+
+#[test]
+fn test_cube_box_wire_format() {
+    let val = PgCube::cube(vec![0.0, 0.0, 1.0, 1.0], 2);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+
+    // ndim(4) + flags(4) + 4 * f64(8) = 40 bytes
+    assert_eq!(buf.len(), 40);
+
+    // ndim = 2
+    assert_eq!(&buf[0..4], &2u32.to_be_bytes());
+    // flags = 0 (not a point)
+    assert_eq!(&buf[4..8], &0u32.to_be_bytes());
+}
+
+// ── Edge cases ──────────────────────────────────────
+
+#[test]
+fn test_cube_zero_dimensions() {
+    let val = PgCube::point(vec![]);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_cube_negative_coords() {
+    let val = PgCube::point(vec![-1.5, -2.5, -3.5]);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgCube::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_cube_decode_too_short() {
+    assert!(PgCube::from_sql(&[0u8; 4]).is_err());
+}
+
+#[test]
+fn test_cube_decode_truncated_coords() {
+    // ndim=2, flags=1 (point), but only 1 f64 instead of 2
+    let mut buf = BytesMut::new();
+    use bytes::BufMut;
+    buf.put_u32(2); // ndim
+    buf.put_u32(1); // flags (point)
+    buf.put_f64(1.0); // only 1 coordinate, need 2
+    assert!(PgCube::from_sql(&buf).is_err());
+}
+
+// ── Display ─────────────────────────────────────────
+
+#[test]
+fn test_cube_point_display() {
+    let val = PgCube::point(vec![1.0, 2.0, 3.0]);
+    assert_eq!(val.to_string(), "(1, 2, 3)");
+}
+
+#[test]
+fn test_cube_box_display() {
+    let val = PgCube::cube(vec![0.0, 0.0, 1.0, 1.0], 2);
+    assert_eq!(val.to_string(), "(0, 0),(1, 1)");
+}
+
+#[test]
+fn test_cube_empty_display() {
+    let val = PgCube::point(vec![]);
+    assert_eq!(val.to_string(), "()");
+}

--- a/tests/core/types/ltree.rs
+++ b/tests/core/types/ltree.rs
@@ -1,0 +1,108 @@
+use bytes::BytesMut;
+use sentinel_driver::types::ltree::{PgLQuery, PgLTree};
+use sentinel_driver::types::{FromSql, Oid, ToSql};
+
+// ── PgLTree ─────────────────────────────────────────
+
+#[test]
+fn test_ltree_roundtrip() {
+    let val = PgLTree("top.science.astronomy".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgLTree::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_ltree_single_label() {
+    let val = PgLTree("root".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgLTree::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_ltree_empty() {
+    let val = PgLTree(String::new());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgLTree::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_ltree_oid() {
+    let val = PgLTree("a.b".into());
+    assert_eq!(val.oid(), Oid::TEXT);
+    assert_eq!(<PgLTree as FromSql>::oid(), Oid::TEXT);
+}
+
+#[test]
+fn test_ltree_wire_format() {
+    let val = PgLTree("a.b.c".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], b"a.b.c");
+}
+
+#[test]
+fn test_ltree_display() {
+    let val = PgLTree("top.science".into());
+    assert_eq!(val.to_string(), "top.science");
+}
+
+#[test]
+fn test_ltree_from_str() {
+    let val: PgLTree = "top.science.astronomy".parse().unwrap();
+    assert_eq!(val.0, "top.science.astronomy");
+}
+
+// ── PgLQuery ────────────────────────────────────────
+
+#[test]
+fn test_lquery_roundtrip() {
+    let val = PgLQuery("*.science.*".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgLQuery::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_lquery_oid() {
+    let val = PgLQuery("*.a".into());
+    assert_eq!(val.oid(), Oid::TEXT);
+    assert_eq!(<PgLQuery as FromSql>::oid(), Oid::TEXT);
+}
+
+#[test]
+fn test_lquery_wire_format() {
+    let val = PgLQuery("top.*{1,3}.astronomy".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], b"top.*{1,3}.astronomy");
+}
+
+#[test]
+fn test_lquery_display() {
+    let val = PgLQuery("*.science.*".into());
+    assert_eq!(val.to_string(), "*.science.*");
+}
+
+#[test]
+fn test_lquery_from_str() {
+    let val: PgLQuery = "*.science.*".parse().unwrap();
+    assert_eq!(val.0, "*.science.*");
+}
+
+// ── Unicode ─────────────────────────────────────────
+
+#[test]
+fn test_ltree_unicode() {
+    let val = PgLTree("top.science.astronomy".into());
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = PgLTree::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}

--- a/tests/core/types/mod.rs
+++ b/tests/core/types/mod.rs
@@ -1,5 +1,6 @@
 mod bit;
 mod builtin;
+mod cube;
 mod decode;
 mod encode;
 mod geometric;
@@ -7,11 +8,14 @@ mod interval;
 #[cfg(feature = "with-serde-json")]
 mod json;
 mod lsn;
+mod ltree;
 mod macaddr8;
 mod money;
 mod multirange;
 mod network;
 mod numeric;
 mod range;
+#[cfg(feature = "with-time")]
+mod time_support;
 mod timetz;
 mod xml;

--- a/tests/core/types/time_support.rs
+++ b/tests/core/types/time_support.rs
@@ -1,0 +1,210 @@
+use bytes::BytesMut;
+use sentinel_driver::types::{FromSql, Oid, ToSql};
+
+// ── OffsetDateTime (TIMESTAMPTZ) ────────────────────
+
+#[test]
+fn test_time_offsetdatetime_roundtrip() {
+    let val = time::macros::datetime!(2026-04-17 12:30:00 UTC);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::OffsetDateTime::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_offsetdatetime_epoch() {
+    // PG epoch: 2000-01-01 00:00:00 UTC should encode as 0
+    let val = time::macros::datetime!(2000-01-01 0:00:00 UTC);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &0i64.to_be_bytes());
+}
+
+#[test]
+fn test_time_offsetdatetime_before_epoch() {
+    // 1999-12-31 23:59:59 UTC = -1_000_000 microseconds from PG epoch
+    let val = time::macros::datetime!(1999-12-31 23:59:59 UTC);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::OffsetDateTime::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_offsetdatetime_with_micros() {
+    let val = time::macros::datetime!(2026-04-17 12:30:00.123456 UTC);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::OffsetDateTime::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_offsetdatetime_oid() {
+    let val = time::macros::datetime!(2026-04-17 0:00:00 UTC);
+    assert_eq!(val.oid(), Oid::TIMESTAMPTZ);
+    assert_eq!(<time::OffsetDateTime as FromSql>::oid(), Oid::TIMESTAMPTZ);
+}
+
+// ── PrimitiveDateTime (TIMESTAMP) ───────────────────
+
+#[test]
+fn test_time_primitivedatetime_roundtrip() {
+    let val = time::macros::datetime!(2026-04-17 12:30:00);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::PrimitiveDateTime::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_primitivedatetime_epoch() {
+    let val = time::macros::datetime!(2000-01-01 0:00:00);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &0i64.to_be_bytes());
+}
+
+#[test]
+fn test_time_primitivedatetime_with_micros() {
+    let val = time::macros::datetime!(2026-04-17 12:30:00.654321);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::PrimitiveDateTime::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_primitivedatetime_oid() {
+    let val = time::macros::datetime!(2026-04-17 0:00:00);
+    assert_eq!(val.oid(), Oid::TIMESTAMP);
+    assert_eq!(<time::PrimitiveDateTime as FromSql>::oid(), Oid::TIMESTAMP);
+}
+
+// ── Date (DATE) ─────────────────────────────────────
+
+#[test]
+fn test_time_date_roundtrip() {
+    let val = time::macros::date!(2026 - 04 - 17);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::Date::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_date_epoch() {
+    // PG epoch: 2000-01-01 should encode as 0 days
+    let val = time::macros::date!(2000 - 01 - 01);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &0i32.to_be_bytes());
+}
+
+#[test]
+fn test_time_date_day_after_epoch() {
+    let val = time::macros::date!(2000 - 01 - 02);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &1i32.to_be_bytes());
+}
+
+#[test]
+fn test_time_date_before_epoch() {
+    let val = time::macros::date!(1999 - 12 - 31);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &(-1i32).to_be_bytes());
+}
+
+#[test]
+fn test_time_date_oid() {
+    let val = time::macros::date!(2026 - 04 - 17);
+    assert_eq!(val.oid(), Oid::DATE);
+    assert_eq!(<time::Date as FromSql>::oid(), Oid::DATE);
+}
+
+// ── Time (TIME) ─────────────────────────────────────
+
+#[test]
+fn test_time_time_roundtrip() {
+    let val = time::macros::time!(12:30:45.123456);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::Time::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_time_midnight() {
+    let val = time::macros::time!(0:00:00);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    assert_eq!(&buf[..], &0i64.to_be_bytes());
+}
+
+#[test]
+fn test_time_time_max() {
+    let val = time::macros::time!(23:59:59.999999);
+    let mut buf = BytesMut::new();
+    val.to_sql(&mut buf).ok();
+    let decoded = time::Time::from_sql(&buf).ok();
+    assert_eq!(decoded, Some(val));
+}
+
+#[test]
+fn test_time_time_oid() {
+    let val = time::macros::time!(12:00:00);
+    assert_eq!(val.oid(), Oid::TIME);
+    assert_eq!(<time::Time as FromSql>::oid(), Oid::TIME);
+}
+
+// ── Cross-compatibility with chrono ─────────────────
+
+#[test]
+fn test_time_date_same_wire_as_chrono() {
+    // Both time::Date and chrono::NaiveDate for 2026-04-17 should produce the same bytes
+    let time_date = time::macros::date!(2026 - 04 - 17);
+    let chrono_date = chrono::NaiveDate::from_ymd_opt(2026, 4, 17).unwrap();
+
+    let mut buf_time = BytesMut::new();
+    let mut buf_chrono = BytesMut::new();
+    time_date.to_sql(&mut buf_time).ok();
+    chrono_date.to_sql(&mut buf_chrono).ok();
+
+    assert_eq!(&buf_time[..], &buf_chrono[..]);
+}
+
+#[test]
+fn test_time_timestamp_same_wire_as_chrono() {
+    let time_dt = time::macros::datetime!(2026-04-17 12:30:00);
+    let chrono_dt = chrono::NaiveDate::from_ymd_opt(2026, 4, 17)
+        .unwrap()
+        .and_hms_opt(12, 30, 0)
+        .unwrap();
+
+    let mut buf_time = BytesMut::new();
+    let mut buf_chrono = BytesMut::new();
+    time_dt.to_sql(&mut buf_time).ok();
+    chrono_dt.to_sql(&mut buf_chrono).ok();
+
+    assert_eq!(&buf_time[..], &buf_chrono[..]);
+}
+
+#[test]
+fn test_time_timestamptz_same_wire_as_chrono() {
+    let time_dt = time::macros::datetime!(2026-04-17 12:30:00 UTC);
+    let chrono_dt = chrono::NaiveDate::from_ymd_opt(2026, 4, 17)
+        .unwrap()
+        .and_hms_opt(12, 30, 0)
+        .unwrap()
+        .and_utc();
+
+    let mut buf_time = BytesMut::new();
+    let mut buf_chrono = BytesMut::new();
+    time_dt.to_sql(&mut buf_time).ok();
+    chrono_dt.to_sql(&mut buf_chrono).ok();
+
+    assert_eq!(&buf_time[..], &buf_chrono[..]);
+}


### PR DESCRIPTION
## Summary
- **Domain types:** Verified existing newtype derive auto-detects single-field structs for `ToSql`/`FromSql` �� works out of the box for PG domain types (`Email(String)`, `UserId(i32)`, etc.)
- **LTREE/LQUERY:** `PgLTree` and `PgLQuery` for hierarchical label tree extension — text wire format, `TEXT` OID carrier
- **CUBE:** `PgCube` for n-dimensional point/box — binary wire format (`ndim + flags + f64[]`)
- **time crate:** Feature-gated `with-time` support for `OffsetDateTime`→TIMESTAMPTZ, `PrimitiveDateTime`→TIMESTAMP, `Date`→DATE, `Time`→TIME — wire-compatible with existing chrono impls

## Test plan
- [x] 12 domain type derive tests (roundtrip, OID delegation, wire format, edge cases)
- [x] 13 LTREE/LQUERY tests (roundtrip, Display, FromStr, Unicode, wire format)
- [x] 15 CUBE tests (point/box roundtrip, wire format, error handling, Display)
- [x] 21 time crate tests (all 4 types roundtrip + epoch + cross-compatibility with chrono)
- [x] 521 total tests pass with `--features with-time`, 500 without
- [x] Zero clippy warnings, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)