### PR TITLE
ci(sonar): switch to sonar.token + skip reinstall when cached

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,6 +10,8 @@ jobs:
   sonarqube:
     name: SonarQube Scan
     runs-on: self-hosted
+    env:
+      SCANNER_VERSION: 5.0.1.3006
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,12 +21,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Install & Run Sonar Scanner
+      - name: Install Sonar Scanner (skip if already present on runner)
+        run: |
+          SCANNER_DIR="/opt/sonar-scanner-${SCANNER_VERSION}-linux"
+          if [ ! -x "$SCANNER_DIR/bin/sonar-scanner" ]; then
+            sudo apt-get update && sudo apt-get install -y unzip
+            curl -sSLo /tmp/sonar-scanner.zip "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SCANNER_VERSION}-linux.zip"
+            sudo unzip -o /tmp/sonar-scanner.zip -d /opt
+          fi
+          sudo ln -sf "$SCANNER_DIR/bin/sonar-scanner" /usr/local/bin/sonar-scanner
+      - name: Run Sonar Scanner
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          sudo apt-get update && sudo apt-get install -y unzip
-          curl -sSLo /tmp/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-5.0.1.3006-linux.zip
-          sudo unzip -o /tmp/sonar-scanner.zip -d /opt
-          sudo ln -sf /opt/sonar-scanner-5.0.1.3006-linux/bin/sonar-scanner /usr/local/bin/sonar-scanner
-          sonar-scanner -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+        run: sonar-scanner -Dsonar.token="$SONAR_TOKEN"


### PR DESCRIPTION
## Change Kind (pick one)

- [ ] ➕ Additive — new pub API, default-off feature, new impl, doc change
- [ ] ⚠️ Breaking — requires \`v2\` branch per \`GOVERNANCE.md\`
- [x] 🧹 Internal — no \`pub\` surface change, tests, refactor, CI

## Self-Verification

- [x] No public API change — CI workflow only
- [x] YAML syntax validated locally (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [x] Behavior preserved — same scanner version, same runner, same secrets

## Summary

Three small fixes to \`.github/workflows/sonar.yml\`:

1. **\`sonar.login\` → \`sonar.token\`** — silences the SonarQube 10.x deprecation warning. \`sonar.login\` still works but will be removed in a future major scanner release.

2. **Skip download+unzip when the scanner is already present** — on a persistent self-hosted runner the scanner survives between runs. Testing for an existing \`/opt/sonar-scanner-\*/bin/sonar-scanner\` avoids a ~200MB download + apt-get + unzip every build. Ephemeral pods still fall through the install branch on first run.

3. **Extract \`SCANNER_VERSION\` env var** — so the download URL and the install directory can't drift apart, and pass \`SONAR_TOKEN\` via \`env:\` instead of expanding the secret into the shell command line (safer).

## Test plan

- [ ] \`SonarQube Scan\` CI run on this PR — should be green (same auth, same upload target)
- [ ] Confirm second run on the same runner reuses the cached scanner (look for absence of the \`curl\` + \`unzip\` steps in the install output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)