### PR TITLE
fix(ci): restore SCANNER_VERSION env + harden curl error handling

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,6 +10,8 @@ jobs:
   sonarqube:
     name: SonarQube Scan
     runs-on: [self-hosted, internal-runner]
+    env:
+      SCANNER_VERSION: 5.0.1.3006
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,7 +26,13 @@ jobs:
           SCANNER_DIR="/opt/sonar-scanner-${SCANNER_VERSION}-linux"
           if [ ! -x "$SCANNER_DIR/bin/sonar-scanner" ]; then
             sudo apt-get update && sudo apt-get install -y unzip
-            curl -sSLo /tmp/sonar-scanner.zip "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SCANNER_VERSION}-linux.zip"
+            if ! curl -fsSLo /tmp/sonar-scanner.zip \
+                 "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SCANNER_VERSION}-linux.zip"; then
+              echo "::error::Failed to download sonar-scanner ${SCANNER_VERSION}"
+              echo "First 500 bytes of partial download (if any):"
+              head -c 500 /tmp/sonar-scanner.zip 2>/dev/null || echo "(file empty or missing)"
+              exit 1
+            fi
             sudo unzip -o /tmp/sonar-scanner.zip -d /opt
           fi
           sudo ln -sf "$SCANNER_DIR/bin/sonar-scanner" /usr/local/bin/sonar-scanner


### PR DESCRIPTION
## Change Kind (pick one)

- [ ] ➕ Additive — new pub API, default-off feature, new impl, doc change
- [ ] ⚠️ Breaking — requires \`v2\` branch per \`GOVERNANCE.md\`
- [x] 🧹 Internal — no \`pub\` surface change, tests, refactor, CI

## Why

SonarQube Scan started failing on main after PR #30 merged
([example failure](https://github.com/cntm-labs/sentinel-driver/actions/runs/24983266384/job/73153470923)):

\`\`\`
End-of-central-directory signature not found.
unzip: cannot find zipfile directory in one of /tmp/sonar-scanner.zip
##[error]Process completed with exit code 9.
\`\`\`

### Root cause — not the runner pool, not egress, not the token

The squash-merge of PR #30 against the \`runs-on\` rewrite in 605bcf6
silently dropped the job-level \`env: SCANNER_VERSION: 5.0.1.3006\`
block I had added.

With \`SCANNER_VERSION\` unset, the install step expanded to:

- \`SCANNER_DIR=/opt/sonar-scanner--linux\`
- \`curl ... sonar-scanner-cli--linux.zip\`

SonarSource's CDN returned a 404 HTML page; \`curl -sSL\` (no \`-f\`) wrote
the HTML body to \`/tmp/sonar-scanner.zip\` and exited 0; \`unzip\` then
failed because the file isn't a zip.

Confirmed by comparing the env section across runs:
- PR #30 success log: \`SCANNER_VERSION: 5.0.1.3006\` is in env
- Failed run on main: no \`SCANNER_VERSION\` line at all

## What this PR does

1. **Restores \`env: SCANNER_VERSION: 5.0.1.3006\`** at job scope so the
   path test and URL both resolve. This is the actual fix.

2. **Hardens curl** with \`-f\` (fail on HTTP error) and dumps the first
   500 bytes of the partial download on failure, so the next time
   something silently misroutes the URL we see a readable diagnostic
   instead of an opaque unzip error.

No runner change, no scanner version change, no auth change.

## Test plan

- [ ] \`SonarQube Scan\` CI run on this PR — should be green again
- [ ] Confirm log shows \`SCANNER_VERSION: 5.0.1.3006\` in the install step's env section

🤖 Generated with [Claude Code](https://claude.com/claude-code)