### PR TITLE
fix(release): align release-please manifest with crates.io reality

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "crates/sentinel-derive": "0.1.1",
-  "crates/sentinel-driver": "0.1.1"
+  "crates/sentinel-derive": "1.0.0",
+  "crates/sentinel-driver": "1.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,14 +4,12 @@
     "crates/sentinel-derive": {
       "release-type": "rust",
       "component": "sentinel-derive",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "release-as": "1.1.0"
     },
     "crates/sentinel-driver": {
       "release-type": "rust",
       "component": "sentinel-driver",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
+      "release-as": "1.1.0",
       "extra-files": [
         {
           "type": "toml",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,13 +3,11 @@
   "packages": {
     "crates/sentinel-derive": {
       "release-type": "rust",
-      "component": "sentinel-derive",
-      "release-as": "1.1.0"
+      "component": "sentinel-derive"
     },
     "crates/sentinel-driver": {
       "release-type": "rust",
       "component": "sentinel-driver",
-      "release-as": "1.1.0",
       "extra-files": [
         {
           "type": "toml",


### PR DESCRIPTION
## Change Kind (pick one)

- [ ] ➕ Additive — new pub API, default-off feature, new impl, doc change
- [ ] ⚠️ Breaking — requires \`v2\` branch per \`GOVERNANCE.md\`
- [x] 🧹 Internal — release-please bookkeeping only, no crate code change

## What this PR does — purely mechanical

Two corrections to release-please bookkeeping. **Zero crate code change. No version-bump strategy decided here.**

| File | Before | After |
|------|--------|-------|
| \`.release-please-manifest.json\` | both crates \`0.1.1\` | both crates \`1.0.0\` (matches what's actually on crates.io since 2026-04-17) |
| \`release-please-config.json\` | \`bump-minor-pre-major\` + \`bump-patch-for-minor-pre-major\` (0.x flags) | both removed (no-ops at 1.x) |

## Why now

Phase 0 (#29) merged on 2026-04-21 but **no Release PR appeared**. Diagnosis:

- crates.io has \`sentinel-driver = 1.0.0\` and \`sentinel-derive = 1.0.0\` published 2026-04-17 (verified via crates.io API).
- Git tags \`sentinel-driver-v1.0.0\` and \`sentinel-derive-v1.0.0\` exist.
- release-please's manifest, however, declares \`0.1.1\` for both — drift introduced when the v1.0.0 bump (#8760f02) was made manually outside the release-please flow.
- release-please workflow runs on every push (visible in Actions, all complete in 17–24s) but creates no Release PR because its declared baseline doesn't match the working tree's Cargo.toml versions.

Fixing the manifest unblocks the bot.

## What this PR explicitly does NOT do

- **Does not pre-decide v1.1.0 vs v2.0.0.** An earlier revision of this branch carried \`release-as: \"1.1.0\"\` — that pre-committed a strategic decision in a mechanical PR. Removed in 1354b0c.
- **Does not republish v1.0.0.** \`cargo publish\` rejects duplicate versions; this PR doesn't touch Cargo.toml at all.
- **Does not run \`semver-checks\`.** Paths filter (\`crates/**\`, \`Cargo.toml\`, \`Cargo.lock\`) does not match the release-please config or manifest, so the gate is correctly bypassed for this PR.

## What happens after merge

release-please will scan main, see the \`feat!: c588017\` commit (Phase 0), and **open a Release PR proposing its default version bump** — likely \`v2.0.0\` because \`feat!\` at 1.x is a major bump under standard semver.

At that point reviewers decide:
- **Accept 2.0.0** → admin-merge the Release PR (no semver-checks bypass needed; major covers the breaks); publish-crates ships it.
- **Override to 1.1.0** → open a follow-up PR adding \`release-as: \"1.1.0\"\` to the config; release-please will refresh the Release PR; admin-bypass semver-checks (with the exception comment from #29); publish; immediately open another PR removing \`release-as\` to avoid getting stuck at 1.1.0 forever.

That decision is **out of scope of this PR** and should not be hardcoded into config until reviewed.

## Test plan

- [x] JSON syntax validated (\`python3 -c \"import json; json.load(open(...))\"\`)
- [x] crates.io baseline verified (\`curl https://crates.io/api/v1/crates/sentinel-driver\`)
- [x] Git tags verified (\`git tag -l\`)
- [ ] CI green on this PR — semver-checks skipped (paths filter)
- [ ] After merge: confirm release-please opens a Release PR, then escalate version-bump decision separately

## Reference

- Design (gitignored): \`docs/plans/2026-04-28-release-infra-fix-design.md\`
- Lesson recorded: \`feedback_release_preflight.md\` memory — never pre-commit release strategy in mechanical fixes
- Phase 0: #29 (commit c588017)
- Original v1.0.0 manual bump: 8760f02

🤖 Generated with [Claude Code](https://claude.com/claude-code)