### PR TITLE
feat!: re-anchor Phase 0 SemVer hardening — document #[non_exhaustive] on Error

### DIFF
--- a/crates/sentinel-driver/src/error.rs
+++ b/crates/sentinel-driver/src/error.rs
@@ -3,7 +3,29 @@ use std::fmt;
 /// Result type alias for sentinel-driver operations.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// All possible errors from sentinel-driver.
+/// All possible errors returned by `sentinel-driver`.
+///
+/// # Stability contract
+///
+/// This enum is `#[non_exhaustive]` as of v1.1.0. New variants may be
+/// added in any future minor release without a major version bump, in
+/// line with the additive-only stability policy in `GOVERNANCE.md`.
+///
+/// What this means for downstream code:
+///
+/// - `?` propagation and `From`/`Into` conversion are unaffected.
+/// - Manual exhaustive `match` arms must include a wildcard `_ =>` arm
+///   to keep compiling against future minor releases. This is the only
+///   migration required by the v1.0 → v1.1 transition.
+///
+/// ```ignore
+/// // OK — has a wildcard arm.
+/// match err {
+///     Error::ConnectionClosed => /* ... */,
+///     Error::TransactionCompleted => /* ... */,
+///     _ => /* ... */,
+/// }
+/// ```
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {


### PR DESCRIPTION
## Change Kind (pick one)

- [ ] ➕ Additive — new pub API, default-off feature, new impl, doc change
- [x] ⚠️ Breaking — re-asserts the Phase 0 break in a release-please-parseable form (the underlying \`#[non_exhaustive]\` change shipped in #29)
- [ ] 🧹 Internal

> ⚠️ **PR title is conventional-commits compliant on purpose.** When this PR is squash-merged, the squash subject becomes the conventional-commit anchor that release-please reads. **Do not edit the title to "Phase 0 ..." or anything that does not start with \`feat!:\` / \`fix:\` / \`feat(scope):\` etc.** The whole point of this PR is that release-please could not parse the previous Phase 0 squash subject — see commit body for the post-mortem.

## Self-Verification

- [x] \`cargo check --workspace --lib\` passes (only a doc-comment change to \`error.rs\`)
- [x] No semantics change — \`#[non_exhaustive]\` was already applied in #29
- [x] Commit subject matches release-please's conventional-commit grammar (\`feat!:\` ✓)

## What this PR is

A single doc-comment-only change on \`crates/sentinel-driver/src/error.rs\` paired with a \`feat!:\`-prefixed conventional commit so release-please can finally identify Phase 0's breaking change and propose a Release PR. The \`#[non_exhaustive]\` attribute itself was applied in c5880177 — this PR only documents the resulting stability contract on the \`Error\` enum's rustdoc.

## Why it is needed

Phase 0 (#29, commit c5880177) shipped \`#[non_exhaustive]\` on \`Error\`, \`Severity\`, and \`ServerError\` — a deliberate, one-time controlled break for the v1.x line. The PR was squash-merged with the title \"Phase 0: non_exhaustive + CI infra + GOVERNANCE\". release-please's conventional-commit parser rejected that title (\"Phase\" is not a recognized type) and dropped the commit, leaving its \`commits considered\` count at zero. The release-please workflow has been running on every push since but produces no Release PR because it sees no parseable changes to release.

The manifest realignment in #32 was a prerequisite (release-please's baseline was stale at \`0.1.1\`); this PR is the second half of the unblock.

## What this PR is NOT

- **Not a version-bump strategy decision.** No \`Release-As\` footer in the commit. release-please will propose its default — almost certainly \`v2.0.0\` because \`feat!\` at 1.x maps to a major bump under standard semver. Whether to accept v2.0.0 or override to v1.1.0 is a separate discussion that happens on the actual Release PR.
- **Not a re-application of the breaking change.** The attribute is already on main. This PR only re-asserts the contract in a parseable form.
- **Not a content change to Phase 0 itself.** Same break, same intent, same migration guide — just expressed where release-please can read it.

## After merge — expected flow

1. release-please scans main, sees this commit's \`feat!:\` subject + breaking-change footer, opens a Release PR (probably proposing \`v2.0.0\`).
2. Reviewers decide on that Release PR: accept \`v2.0.0\`, or open a follow-up adding \`release-as: \"1.1.0\"\` to \`release-please-config.json\` to override.
3. Whichever version is chosen, that Release PR will fail \`semver-checks\` (the same three break findings from #29). Admin-merge with the same exception comment we drafted on #29.
4. After merge, \`publish-crates\` step runs and ships both crates to crates.io.
5. **If \`release-as\` was used in step 2: open one more PR removing it immediately so the next minor isn't stuck at the override version forever.**

## Going-forward policy proposal

This entire problem was created by a non-conventional-commits squash subject. To prevent recurrence, branch protection should require PR titles to match the conventional-commits grammar before squash-merge. That is *out of scope of this PR* but should land before the next breaking change.

## Reference

- Phase 0 implementation: c5880177 (#29)
- Manifest realignment: e9b1315 (#32)
- Stability contract: \`GOVERNANCE.md\` §1
- Design (gitignored, local): \`docs/plans/2026-04-28-release-infra-fix-design.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)