### PR TITLE
feat(types): support Vec<Option<T>> for arrays with NULL elements

### DIFF
--- a/crates/sentinel-driver/src/types/decode.rs
+++ b/crates/sentinel-driver/src/types/decode.rs
@@ -314,10 +314,7 @@ fn decode_array<T: FromSql>(buf: &[u8], expected_elem_oid: Oid) -> Result<Vec<T>
     })
 }
 
-fn decode_array_nullable<T: FromSql>(
-    buf: &[u8],
-    expected_elem_oid: Oid,
-) -> Result<Vec<Option<T>>> {
+fn decode_array_nullable<T: FromSql>(buf: &[u8], expected_elem_oid: Oid) -> Result<Vec<Option<T>>> {
     decode_array_inner(buf, expected_elem_oid, |opt| match opt {
         Some(bytes) => T::from_sql(bytes).map(Some),
         None => Ok(None),

--- a/crates/sentinel-driver/src/types/decode.rs
+++ b/crates/sentinel-driver/src/types/decode.rs
@@ -231,13 +231,28 @@ fn read_u32(buf: &[u8], offset: usize) -> u32 {
     ])
 }
 
-fn decode_array<T: FromSql>(buf: &[u8], expected_elem_oid: Oid) -> Result<Vec<T>> {
+/// Walk a one-dimensional PG array, calling `decode_elem` for each slot.
+///
+/// `decode_elem` receives `Some(&[u8])` for non-NULL element bodies and
+/// `None` for SQL NULL (signalled by a per-element length of `-1` in the
+/// PG binary array wire format). The closure decides what to do in each
+/// case — non-nullable callers raise an error on `None`; nullable callers
+/// map it to a sentinel value such as `Option::None`.
+fn decode_array_inner<T, F>(
+    buf: &[u8],
+    expected_elem_oid: Oid,
+    mut decode_elem: F,
+) -> Result<Vec<T>>
+where
+    F: FnMut(Option<&[u8]>) -> Result<T>,
+{
     if buf.len() < 12 {
         return Err(Error::Decode("array: header too short".into()));
     }
 
     let ndim = read_i32(buf, 0);
-    // has_null at buf[4..8] — we reject NULLs in element loop
+    // has_null at buf[4..8] is informational; the per-element length
+    // sentinel is the authoritative source for NULL.
     let elem_oid = read_u32(buf, 8);
 
     if ndim == 0 {
@@ -276,23 +291,49 @@ fn decode_array<T: FromSql>(buf: &[u8], expected_elem_oid: Oid) -> Result<Vec<T>
         offset += 4;
 
         if elem_len < 0 {
-            return Err(Error::Decode("array: NULL elements not supported".into()));
+            result.push(decode_elem(None)?);
+        } else {
+            let elem_len = elem_len as usize;
+            if offset + elem_len > buf.len() {
+                return Err(Error::Decode("array: element data truncated".into()));
+            }
+            result.push(decode_elem(Some(&buf[offset..offset + elem_len]))?);
+            offset += elem_len;
         }
-
-        let elem_len = elem_len as usize;
-        if offset + elem_len > buf.len() {
-            return Err(Error::Decode("array: element data truncated".into()));
-        }
-
-        let elem = T::from_sql(&buf[offset..offset + elem_len])?;
-        result.push(elem);
-        offset += elem_len;
     }
 
     Ok(result)
 }
 
-/// Macro to implement `FromSql` for `Vec<T>` for a specific element type.
+fn decode_array<T: FromSql>(buf: &[u8], expected_elem_oid: Oid) -> Result<Vec<T>> {
+    decode_array_inner(buf, expected_elem_oid, |opt| match opt {
+        Some(bytes) => T::from_sql(bytes),
+        None => Err(Error::Decode(
+            "array: NULL elements not supported (use Vec<Option<T>>)".into(),
+        )),
+    })
+}
+
+fn decode_array_nullable<T: FromSql>(
+    buf: &[u8],
+    expected_elem_oid: Oid,
+) -> Result<Vec<Option<T>>> {
+    decode_array_inner(buf, expected_elem_oid, |opt| match opt {
+        Some(bytes) => T::from_sql(bytes).map(Some),
+        None => Ok(None),
+    })
+}
+
+/// Implement `FromSql` for both `Vec<T>` and `Vec<Option<T>>` for a
+/// specific element type.
+///
+/// - `Vec<T>` errors on any SQL NULL element with a message that points
+///   the caller at `Vec<Option<T>>`.
+/// - `Vec<Option<T>>` maps SQL NULL to `Option::None`.
+///
+/// Both impls advertise the same array OID; PostgreSQL does not carry a
+/// distinct "nullable element" array type — nullability is per-element on
+/// the wire.
 macro_rules! impl_array_from_sql {
     ($elem_ty:ty, $array_oid:expr, $elem_oid:expr) => {
         impl FromSql for Vec<$elem_ty> {
@@ -302,6 +343,16 @@ macro_rules! impl_array_from_sql {
 
             fn from_sql(buf: &[u8]) -> Result<Self> {
                 decode_array::<$elem_ty>(buf, $elem_oid)
+            }
+        }
+
+        impl FromSql for Vec<Option<$elem_ty>> {
+            fn oid() -> Oid {
+                $array_oid
+            }
+
+            fn from_sql(buf: &[u8]) -> Result<Self> {
+                decode_array_nullable::<$elem_ty>(buf, $elem_oid)
             }
         }
     };
@@ -370,5 +421,15 @@ impl FromSql for Vec<Vec<u8>> {
 
     fn from_sql(buf: &[u8]) -> Result<Self> {
         decode_array::<Vec<u8>>(buf, Oid::BYTEA)
+    }
+}
+
+impl FromSql for Vec<Option<Vec<u8>>> {
+    fn oid() -> Oid {
+        Oid::BYTEA_ARRAY
+    }
+
+    fn from_sql(buf: &[u8]) -> Result<Self> {
+        decode_array_nullable::<Vec<u8>>(buf, Oid::BYTEA)
     }
 }

--- a/tests/core/types/decode.rs
+++ b/tests/core/types/decode.rs
@@ -515,7 +515,11 @@ fn test_decode_vec_option_string_with_null() {
     let got = <Vec<Option<String>> as FromSql>::from_sql(&buf).unwrap();
     assert_eq!(
         got,
-        vec![Some(String::from("hello")), None, Some(String::from("world"))]
+        vec![
+            Some(String::from("hello")),
+            None,
+            Some(String::from("world"))
+        ]
     );
 }
 
@@ -523,10 +527,7 @@ fn test_decode_vec_option_string_with_null() {
 fn test_decode_vec_option_bool_with_null() {
     let t = [1u8];
     let f = [0u8];
-    let buf = build_pg_array(
-        sentinel_driver::Oid::BOOL.0,
-        &[Some(&t), None, Some(&f)],
-    );
+    let buf = build_pg_array(sentinel_driver::Oid::BOOL.0, &[Some(&t), None, Some(&f)]);
     let got = <Vec<Option<bool>> as FromSql>::from_sql(&buf).unwrap();
     assert_eq!(got, vec![Some(true), None, Some(false)]);
 }

--- a/tests/core/types/decode.rs
+++ b/tests/core/types/decode.rs
@@ -420,3 +420,139 @@ fn test_option_from_sql() {
     let result: Option<i32> = FromSql::from_sql_nullable(Some(&buf)).unwrap();
     assert_eq!(result, Some(42));
 }
+
+// ---------------------------------------------------------------------------
+// Nullable array decoding — `Vec<Option<T>>` (issue #33)
+// ---------------------------------------------------------------------------
+
+/// Build a one-dimensional PG binary-array body for the given element OID.
+///
+/// Each element is either `Some(bytes)` (a non-NULL element body) or
+/// `None` (SQL NULL, encoded as a per-element length of `-1`).
+fn build_pg_array(elem_oid: u32, elems: &[Option<&[u8]>]) -> Vec<u8> {
+    let mut out = Vec::new();
+    let has_null = elems.iter().any(Option::is_none) as i32;
+    out.extend_from_slice(&1i32.to_be_bytes()); // ndim
+    out.extend_from_slice(&has_null.to_be_bytes());
+    out.extend_from_slice(&elem_oid.to_be_bytes());
+    out.extend_from_slice(&(elems.len() as i32).to_be_bytes()); // dim_len
+    out.extend_from_slice(&1i32.to_be_bytes()); // dim_lbound
+    for e in elems {
+        match e {
+            Some(body) => {
+                out.extend_from_slice(&(body.len() as i32).to_be_bytes());
+                out.extend_from_slice(body);
+            }
+            None => {
+                out.extend_from_slice(&(-1i32).to_be_bytes());
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn test_decode_vec_option_i32_with_null() {
+    let one = 1i32.to_be_bytes();
+    let three = 3i32.to_be_bytes();
+    let buf = build_pg_array(
+        sentinel_driver::Oid::INT4.0,
+        &[Some(&one), None, Some(&three)],
+    );
+    let got = <Vec<Option<i32>> as FromSql>::from_sql(&buf).unwrap();
+    assert_eq!(got, vec![Some(1), None, Some(3)]);
+}
+
+#[test]
+fn test_decode_vec_option_i32_no_nulls() {
+    let a = 7i32.to_be_bytes();
+    let b = 8i32.to_be_bytes();
+    let buf = build_pg_array(sentinel_driver::Oid::INT4.0, &[Some(&a), Some(&b)]);
+    let got = <Vec<Option<i32>> as FromSql>::from_sql(&buf).unwrap();
+    assert_eq!(got, vec![Some(7), Some(8)]);
+}
+
+#[test]
+fn test_decode_vec_option_i32_all_null() {
+    let buf = build_pg_array(sentinel_driver::Oid::INT4.0, &[None, None, None]);
+    let got = <Vec<Option<i32>> as FromSql>::from_sql(&buf).unwrap();
+    assert_eq!(got, vec![None, None, None]);
+}
+
+#[test]
+fn test_decode_vec_option_empty() {
+    // ndim=0 — short-circuit path returns empty Vec without touching the
+    // header beyond the first 12 bytes.
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&0i32.to_be_bytes()); // ndim = 0
+    buf.extend_from_slice(&0i32.to_be_bytes()); // has_null
+    buf.extend_from_slice(&sentinel_driver::Oid::INT4.0.to_be_bytes());
+    let got = <Vec<Option<i32>> as FromSql>::from_sql(&buf).unwrap();
+    assert!(got.is_empty());
+}
+
+#[test]
+fn test_decode_vec_i32_rejects_null_with_helpful_message() {
+    let one = 1i32.to_be_bytes();
+    let buf = build_pg_array(sentinel_driver::Oid::INT4.0, &[Some(&one), None]);
+    let err = <Vec<i32> as FromSql>::from_sql(&buf).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("NULL"), "expected NULL error, got: {msg}");
+    assert!(
+        msg.contains("Vec<Option<T>>"),
+        "expected suggestion to use Vec<Option<T>>, got: {msg}"
+    );
+}
+
+#[test]
+fn test_decode_vec_option_string_with_null() {
+    let hello = b"hello";
+    let world = b"world";
+    let buf = build_pg_array(
+        sentinel_driver::Oid::TEXT.0,
+        &[Some(hello), None, Some(world)],
+    );
+    let got = <Vec<Option<String>> as FromSql>::from_sql(&buf).unwrap();
+    assert_eq!(
+        got,
+        vec![Some(String::from("hello")), None, Some(String::from("world"))]
+    );
+}
+
+#[test]
+fn test_decode_vec_option_bool_with_null() {
+    let t = [1u8];
+    let f = [0u8];
+    let buf = build_pg_array(
+        sentinel_driver::Oid::BOOL.0,
+        &[Some(&t), None, Some(&f)],
+    );
+    let got = <Vec<Option<bool>> as FromSql>::from_sql(&buf).unwrap();
+    assert_eq!(got, vec![Some(true), None, Some(false)]);
+}
+
+#[test]
+fn test_decode_vec_option_bytea_with_null() {
+    let blob = &[0xde, 0xad, 0xbe, 0xef][..];
+    let buf = build_pg_array(sentinel_driver::Oid::BYTEA.0, &[Some(blob), None]);
+    let got = <Vec<Option<Vec<u8>>> as FromSql>::from_sql(&buf).unwrap();
+    assert_eq!(got, vec![Some(blob.to_vec()), None]);
+}
+
+#[test]
+fn test_decode_vec_option_oid_matches_array_oid() {
+    // Vec<Option<i32>> must advertise the same array OID as Vec<i32> so
+    // server-side type checks accept either at a parameter slot.
+    assert_eq!(
+        <Vec<Option<i32>> as FromSql>::oid(),
+        <Vec<i32> as FromSql>::oid()
+    );
+    assert_eq!(
+        <Vec<Option<String>> as FromSql>::oid(),
+        <Vec<String> as FromSql>::oid()
+    );
+    assert_eq!(
+        <Vec<Option<Vec<u8>>> as FromSql>::oid(),
+        <Vec<Vec<u8>> as FromSql>::oid()
+    );
+}

--- a/tests/postgres/array_nullable.rs
+++ b/tests/postgres/array_nullable.rs
@@ -1,0 +1,148 @@
+//! Live-PostgreSQL coverage for nullable array decoding (issue #33).
+//!
+//! Verifies that `Vec<Option<T>>` round-trips against the server for the
+//! types listed on the issue. Each test runs only when `DATABASE_URL` is
+//! set, mirroring the convention used by the rest of `tests/postgres/`.
+
+use sentinel_driver::{Config, Connection};
+
+fn database_url() -> Option<String> {
+    std::env::var("DATABASE_URL").ok()
+}
+
+macro_rules! require_pg {
+    () => {
+        match database_url() {
+            Some(url) => url,
+            None => return,
+        }
+    };
+}
+
+async fn connect() -> Connection {
+    let url = database_url().expect("require_pg! gates this");
+    let config = Config::parse(&url).unwrap();
+    Connection::connect(config).await.unwrap()
+}
+
+#[tokio::test]
+async fn test_int4_array_with_null() {
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn
+        .query("SELECT ARRAY[1, NULL, 3]::int4[]", &[])
+        .await
+        .unwrap();
+
+    let got: Vec<Option<i32>> = rows[0].get(0);
+    assert_eq!(got, vec![Some(1), None, Some(3)]);
+}
+
+#[tokio::test]
+async fn test_text_array_with_null() {
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn
+        .query("SELECT ARRAY['a', NULL, 'c']::text[]", &[])
+        .await
+        .unwrap();
+
+    let got: Vec<Option<String>> = rows[0].get(0);
+    assert_eq!(
+        got,
+        vec![Some("a".to_string()), None, Some("c".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn test_bool_array_with_null() {
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn
+        .query("SELECT ARRAY[true, NULL, false]::bool[]", &[])
+        .await
+        .unwrap();
+
+    let got: Vec<Option<bool>> = rows[0].get(0);
+    assert_eq!(got, vec![Some(true), None, Some(false)]);
+}
+
+#[tokio::test]
+async fn test_int4_array_no_nulls_via_option() {
+    // `Vec<Option<T>>` must also accept arrays that happen to have no NULLs.
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn.query("SELECT ARRAY[1, 2, 3]::int4[]", &[]).await.unwrap();
+
+    let got: Vec<Option<i32>> = rows[0].get(0);
+    assert_eq!(got, vec![Some(1), Some(2), Some(3)]);
+}
+
+#[tokio::test]
+async fn test_int4_array_all_null() {
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn
+        .query(
+            "SELECT ARRAY[NULL, NULL, NULL]::int4[]",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let got: Vec<Option<i32>> = rows[0].get(0);
+    assert_eq!(got, vec![None, None, None]);
+}
+
+#[tokio::test]
+async fn test_int4_array_with_null_rejected_by_non_option_vec() {
+    // The historical `Vec<i32>` decode path must keep erroring on NULL,
+    // and the error message must point at `Vec<Option<T>>`.
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn
+        .query("SELECT ARRAY[1, NULL, 3]::int4[]", &[])
+        .await
+        .unwrap();
+
+    let result = std::panic::catch_unwind(|| {
+        let _: Vec<i32> = rows[0].get(0);
+    });
+    assert!(
+        result.is_err(),
+        "Vec<i32> decode of an array containing NULL must panic"
+    );
+}
+
+#[tokio::test]
+async fn test_uuid_array_with_null() {
+    let _ = require_pg!();
+    let mut conn = connect().await;
+
+    let rows = conn
+        .query(
+            "SELECT ARRAY[\
+             '550e8400-e29b-41d4-a716-446655440000'::uuid, \
+             NULL, \
+             '00000000-0000-0000-0000-000000000000'::uuid\
+             ]::uuid[]",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let got: Vec<Option<uuid::Uuid>> = rows[0].get(0);
+    assert_eq!(got.len(), 3);
+    assert_eq!(
+        got[0],
+        Some(uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap())
+    );
+    assert_eq!(got[1], None);
+    assert_eq!(got[2], Some(uuid::Uuid::nil()));
+}

--- a/tests/postgres/array_nullable.rs
+++ b/tests/postgres/array_nullable.rs
@@ -76,7 +76,10 @@ async fn test_int4_array_no_nulls_via_option() {
     let _ = require_pg!();
     let mut conn = connect().await;
 
-    let rows = conn.query("SELECT ARRAY[1, 2, 3]::int4[]", &[]).await.unwrap();
+    let rows = conn
+        .query("SELECT ARRAY[1, 2, 3]::int4[]", &[])
+        .await
+        .unwrap();
 
     let got: Vec<Option<i32>> = rows[0].get(0);
     assert_eq!(got, vec![Some(1), Some(2), Some(3)]);
@@ -88,10 +91,7 @@ async fn test_int4_array_all_null() {
     let mut conn = connect().await;
 
     let rows = conn
-        .query(
-            "SELECT ARRAY[NULL, NULL, NULL]::int4[]",
-            &[],
-        )
+        .query("SELECT ARRAY[NULL, NULL, NULL]::int4[]", &[])
         .await
         .unwrap();
 

--- a/tests/postgres/mod.rs
+++ b/tests/postgres/mod.rs
@@ -1,3 +1,4 @@
+mod array_nullable;
 mod stream;
 
 use std::time::Duration;


### PR DESCRIPTION
Closes #33.

## Change Kind

- [x] ➕ Additive — new \`impl FromSql for Vec<Option<T>>\` for every existing array element type. No existing signature changes.
- [ ] ⚠️ Breaking
- [ ] 🧹 Internal

## Self-Verification

- [x] \`cargo test -p sentinel-driver --test core_tests\` — 509 passing (up from 500)
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] PR title is conventional-commits compliant (\`feat(types):\`) — squash subject will be release-please-parseable

## What this adds

\`FromSql for Vec<Option<T>>\` for every array element type already covered by \`impl_array_from_sql!\` plus a hand-written impl for \`Vec<Option<Vec<u8>>>\` (BYTEA arrays). When a PostgreSQL array carries SQL NULL elements, callers decoding into \`Vec<Option<T>>\` now see \`Option::None\` at those slots instead of getting a runtime decode error.

\`Vec<T>\` (the existing path) continues to reject NULL elements unchanged; the error message now points the caller at the new type:

> \`array: NULL elements not supported (use Vec<Option<T>>)\`

## Why

The sentinel ORM is shipping its Cluster A macro work which auto-emits \`Vec<Option<T>>\` whenever a query's metadata says an array column's element type can be NULL. Without driver support that generated code compiles but panics on the first NULL-bearing row. This brings sentinel-driver to parity with sqlx, where \`Vec<Option<T>>\` round-trips natively.

## Implementation

\`decode_array\` is refactored into \`decode_array_inner\` which takes a closure receiving \`Option<&[u8]>\` (Some = non-NULL body, None = the \`-1\` per-element length PostgreSQL uses on the wire to mark NULL). Two thin shims sit on top:

- \`decode_array<T>\` — errors on \`None\` (with the new message)
- \`decode_array_nullable<T>\` — maps \`None\` → \`Option::None\`

The \`impl_array_from_sql!\` macro now emits both \`Vec<T>\` and \`Vec<Option<T>>\` impls for each element type. No caller-side change needed; existing invocations unchanged.

Both impls advertise the same array OID — PostgreSQL doesn't carry a distinct nullable-element array type, so server-side parameter type checks accept either at any parameter slot.

## Test plan

- [x] 9 new unit tests in \`tests/core/types/decode.rs\` (with-NULL / no-NULL / all-NULL / empty / BYTEA / BOOL / TEXT, OID parity, improved error message)
- [x] 7 live-PG integration tests in \`tests/postgres/array_nullable.rs\` (INT4, TEXT, BOOL, UUID + edge cases) — gated on \`DATABASE_URL\` and validated by compat-matrix
- [ ] compat-matrix CI green on this PR

## Out of scope (per issue #33)

- Multi-dimensional arrays (\`Vec<Vec<T>>\`) — separate design
- \`ToSql for Vec<Option<T>>\` — issue scope is decode-only; the ORM macro consumes server output. Encode parity can land as a follow-up if user demand surfaces
- User-defined composite element types
- Lifting \`query_typed_*\` into \`GenericClient\`

## Related

- Issue: #33
- Phase 2 design doc: \`docs/plans/2026-04-28-phase2-quickwins-design.md\` (gitignored, local) — this is Gap B of that design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)