### PR TITLE
fix(ci): drop sentinel-derive step from semver-checks workflow

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -23,5 +23,10 @@ jobs:
         run: cargo install cargo-semver-checks --locked
       - name: Check sentinel-driver SemVer
         run: cargo semver-checks check-release -p sentinel-driver
-      - name: Check sentinel-derive SemVer
-        run: cargo semver-checks check-release -p sentinel-derive
+      # `sentinel-derive` is a proc-macro crate. cargo-semver-checks only
+      # analyses library targets (it inspects the public Rust API surface
+      # via rustdoc JSON), so it cannot meaningfully check proc-macros and
+      # exits with `error: no crates with library targets selected`. The
+      # macro's stability contract — input syntax it accepts and the
+      # tokens it emits — is not visible to the tool. We rely on the
+      # crate's own UI/integration tests for that surface instead.


### PR DESCRIPTION
## Change Kind

- [ ] ➕ Additive
- [ ] ⚠️ Breaking
- [x] 🧹 Internal — CI workflow fix; no crate code or pub surface change

## Self-Verification (each box was actually executed)

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/semver-checks.yml'))\"\` — YAML valid
- [x] \`cargo fmt --all -- --check\` — clean (per \`feedback_verify_before_claiming\` lesson)
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] No code change so no test run needed
- [x] PR title is conventional-commits compliant (\`fix(ci):\`)

## Why

\`cargo-semver-checks\` only analyses library targets — it inspects the public Rust API surface via rustdoc JSON. \`sentinel-derive\` is a proc-macro crate, which has no library target, so the tool exits with:

\`\`\`
error: no crates with library targets selected, nothing to semver-check
note: skipped the following crates since they have no library target: sentinel-derive
\`\`\`

The previous workflow ran two steps:

| Step | Result |
|------|--------|
| Check sentinel-driver SemVer | works — sentinel-driver has a library target |
| Check sentinel-derive SemVer | always errors — sentinel-derive is a proc-macro |

Both steps had been firing since Phase 0 set up the gate, but the sentinel-derive failure was silently masked: PRs #29 and #34 failed at the sentinel-driver step (the documented Phase 0 breaks), so the sentinel-derive step never ran. Once the v1.0.0 → v2.0.0 bump on Release PR #36 made the sentinel-driver step pass cleanly, the sentinel-derive step finally ran and failed — blocking the release.

## What this PR does

Removes the \`Check sentinel-derive SemVer\` step entirely and replaces it with a comment explaining why. The proc-macro crate's stability contract — its input grammar and emitted tokens — is not something \`cargo-semver-checks\` can verify; that surface is covered by the macro's own UI / integration tests in \`crates/sentinel-derive/tests/\`.

## Why not \`|| true\`

Hiding a tool error with \`|| true\` would mask a real regression if cargo-semver-checks ever grows proc-macro support. Removing the step entirely is the documented behaviour.

## Path / CI impact

\`semver-checks.yml\` itself only runs on \`crates/**\`, \`Cargo.toml\`, \`Cargo.lock\` paths — this PR touches none of those, so it does not exercise its own gate. Lint/Test/Coverage will run normally.

## Reference

- Release PR: #36 (proposes \`sentinel-driver: 2.0.0\`)
- Phase 0 set up the gate originally: #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)