### PR TITLE
fix(ci): skip per-crate publish when version already on crates.io

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -24,16 +24,41 @@ jobs:
       - name: Verify tests pass
         run: cargo test --workspace
 
+      # Skip per-crate publish if the local version already exists on
+      # crates.io. cargo publish errors with `crate X@Y already exists on
+      # crates.io index` otherwise — that's the right behaviour for an
+      # accidental re-publish, but breaks the manual-fallback flow when
+      # only one crate in the workspace has a new version (the common
+      # case for release-please's per-component releases).
+
+      - name: Compute publish targets
+        id: targets
+        run: |
+          set -euo pipefail
+          for crate in sentinel-derive sentinel-driver; do
+            local_ver=$(grep '^version' "crates/${crate}/Cargo.toml" | head -1 | cut -d'"' -f2)
+            pub_ver=$(curl -fsSL "https://crates.io/api/v1/crates/${crate}" | jq -r '.crate.max_version')
+            if [ "$local_ver" = "$pub_ver" ]; then
+              echo "${crate}_publish=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::${crate} ${local_ver} already on crates.io — skipping publish step"
+            else
+              echo "${crate}_publish=true" >> "$GITHUB_OUTPUT"
+              echo "::notice::${crate}: local ${local_ver} differs from published ${pub_ver} — will publish"
+            fi
+          done
+
       - name: Publish sentinel-derive
+        if: steps.targets.outputs.sentinel-derive_publish == 'true'
         run: cargo publish -p sentinel-derive --no-verify ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait for crates.io index
-        if: inputs.dry-run == 'false'
+        if: inputs.dry-run == 'false' && steps.targets.outputs.sentinel-derive_publish == 'true'
         run: sleep 30
 
       - name: Publish sentinel-driver
+        if: steps.targets.outputs.sentinel-driver_publish == 'true'
         run: cargo publish -p sentinel-driver --no-verify ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Change Kind

- [ ] ➕ Additive
- [ ] ⚠️ Breaking
- [x] 🧹 Internal — manual-fallback workflow fix; no crate code change

## Self-Verification (each box was actually executed)

- [x] \`python3 -c \"import yaml; yaml.safe_load(open(...))\"\` — YAML valid
- [x] \`cargo fmt --all -- --check\` — clean
- [x] No code change so no test run needed
- [x] PR title is conventional-commits compliant (\`fix(ci):\`)

## Why

The manual \`publish-crates.yml\` always tried to publish both crates. During the v2.0.0 release just now, only \`sentinel-driver\` had a new version — \`sentinel-derive\` stayed at \`1.0.0\`. The first step ran \`cargo publish -p sentinel-derive\` which errored with:

\`\`\`
error: crate sentinel-derive@1.0.0 already exists on crates.io index
\`\`\`

\`set -e\` stopped the workflow there, so \`sentinel-driver 2.0.0\` never made it to crates.io despite tag + GitHub Release being published.

This is a real-world hole: every release-please-style per-component release where only one crate moves will hit it.

## What this PR does

Adds a \`Compute publish targets\` step that:

1. Reads each crate's local \`Cargo.toml\` version.
2. Reads the published \`max_version\` from crates.io's public API.
3. Sets a per-crate output flag.

Each \`cargo publish\` step is then gated on its flag — crates already at their published version are skipped with a \`::notice::\`; only those with a new version run.

## Path / CI impact

Only \`.github/workflows/publish-crates.yml\` changes. \`semver-checks\` and \`compat-matrix\` path filters don't match, so they stay quiet. Lint/Test/Coverage will run normally (no crate code change → trivial).

## Follow-up

After this lands, re-run \`publish-crates\` workflow to actually publish \`sentinel-driver 2.0.0\`. \`sentinel-derive\` will be skipped by the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)