### PR TITLE
fix(ci): send User-Agent header when querying crates.io API

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -35,9 +35,13 @@ jobs:
         id: targets
         run: |
           set -euo pipefail
+          # crates.io's public API rejects requests without a User-Agent
+          # (HTTP 403). Be explicit so the step doesn't break in fresh
+          # CI environments where curl's default UA is missing.
+          UA="cntm-labs-sentinel-driver-publish (github.com/cntm-labs/sentinel-driver)"
           for crate in sentinel-derive sentinel-driver; do
             local_ver=$(grep '^version' "crates/${crate}/Cargo.toml" | head -1 | cut -d'"' -f2)
-            pub_ver=$(curl -fsSL "https://crates.io/api/v1/crates/${crate}" | jq -r '.crate.max_version')
+            pub_ver=$(curl -fsSL -H "User-Agent: ${UA}" "https://crates.io/api/v1/crates/${crate}" | jq -r '.crate.max_version')
             if [ "$local_ver" = "$pub_ver" ]; then
               echo "${crate}_publish=false" >> "$GITHUB_OUTPUT"
               echo "::notice::${crate} ${local_ver} already on crates.io — skipping publish step"


### PR DESCRIPTION
## Change Kind

- [x] 🧹 Internal — workflow follow-up to #38; no crate code change

## Self-Verification

- [x] YAML valid (\`python3 yaml.safe_load\`)
- [x] PR title is conventional-commits compliant

## Why

#38 added a step that queries crates.io's public API to decide whether to publish each crate. \`curl -fsSL\` was used without an explicit \`User-Agent\` header. crates.io rejects User-Agent-less requests with HTTP 403:

\`\`\`
curl: (22) The requested URL returned error: 403
##[error]Process completed with exit code 22.
\`\`\`

This blocked the manual publish for v2.0.0.

## What this PR does

Adds an explicit \`User-Agent: cntm-labs-sentinel-driver-publish (github.com/cntm-labs/sentinel-driver)\` header on the \`curl\` call, plus a short comment explaining why.

## Follow-up

After this lands, re-run \`publish-crates\` workflow to actually publish \`sentinel-driver 2.0.0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)